### PR TITLE
Fix #50

### DIFF
--- a/src/edit_dist.h
+++ b/src/edit_dist.h
@@ -4,6 +4,7 @@
 #include <bitset>
 #include <algorithm>
 #include <stdlib.h>
+#include <cstdint>
 
 namespace scutil{
     int hamming_distance(const std::string &A, const std::string &B);


### PR DESCRIPTION
Fixes compilation error for match_cell_barcode.

I just followed the GCC's suggestion based on the error message from #50. 
Compilation succeeded after that. But I didn't test it with different versions of LibC or GCC.